### PR TITLE
Update pbr_rules.yml

### DIFF
--- a/tasks/pbr_rules.yml
+++ b/tasks/pbr_rules.yml
@@ -128,7 +128,7 @@
         item.state == "present" and
         (item.source is defined and
         item.destination is defined) and
-        item.source not in ip_rule_list.results[0].stdout
+        item.source + ' to ' +  item.destination not in ip_rule_list.results[0].stdout
 
 # We do this to automatically enable rules and not require a reboot or
 # restarting networking
@@ -309,3 +309,4 @@
   with_items: '{{ policy_based_routing_rules }}'
   when: >
         item.state == "absent"
+        item.table not in ip_rule_list.results[0].stdout


### PR DESCRIPTION
When source and destination are defined you need to search for the following sentence "source to destination" in the rules list or it can be lead to strange behaviour in certain conditions (line 131).
You use two value to identifying your routing tables, there the rule id that currently the table id in your code and the table name, if you specified several rules with different rule id and the same table name you going to have a complete mess in the rt_table file.
In the case of you use the same table name and rule id as i do you need to verify that there is no rules linked to this table before deleting it (line 312).